### PR TITLE
Add RLlib self-play training

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,10 @@ The new script `agent/multiagent_selfplay.py` demonstrates how two independent P
 
 Run the script as a normal Python module once the dependencies from `pyproject.toml` are installed.
 
-
 uv run python -m agent.test
+
+## 4-agent self-play
+
+`agent/train_rllib_selfplay.py` uses RLlib to train one PPO policy per player in a 4-agent self-play scenario. The algorithm periodically reports the mean episode reward and saves all policies once training finishes.
+
+uv run python -m agent.train_rllib_selfplay

--- a/agent/train_rllib_selfplay.py
+++ b/agent/train_rllib_selfplay.py
@@ -1,0 +1,46 @@
+import ray
+from ray.rllib.algorithms.ppo import PPOConfig
+
+from env.blokus_env_multi_agent import BlokusMultiAgentEnv
+
+
+def main():
+    """Train four PPO policies in self‑play using RLlib."""
+    # Instantiate once to obtain spaces and agent ids
+    temp_env = BlokusMultiAgentEnv()
+    policy_ids = temp_env.agent_ids
+    obs_space = temp_env.observation_space
+    act_space = temp_env.action_space
+
+    policies = {
+        pid: (None, obs_space, act_space, {})
+        for pid in policy_ids
+    }
+
+    def policy_mapping_fn(agent_id, *args, **kwargs):
+        # Each agent uses its own policy
+        return agent_id
+
+    config = (
+        PPOConfig()
+        .environment(BlokusMultiAgentEnv)
+        .framework("torch")
+        .rollouts(num_rollout_workers=0)
+        .multi_agent(
+            policies=policies,
+            policy_mapping_fn=policy_mapping_fn,
+            policies_to_train=list(policy_ids),
+        )
+    )
+
+    algo = config.build()
+
+    for i in range(10):
+        result = algo.train()
+        print(f"Iteration {i}: episode_reward_mean = {result['episode_reward_mean']}")
+
+    algo.save("rllib_blokus_agents")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add RLlib-based self-play training script
- document usage of new RLlib script for 4-agent self-play

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium', 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6848507788148331a4163fdf4897891b