### PR TITLE
Add documentation and requirements

### DIFF
--- a/Agent.md
+++ b/Agent.md
@@ -1,0 +1,29 @@
+# Agenten-Dokumentation
+
+Dieses Dokument beschreibt die vorhandenen Trainingsskripte und deren Verwendung.
+
+## Zwei-Agenten-Selbstspiel
+
+`agent/multiagent_selfplay.py` trainiert zwei unabhängige PPO-Agenten, die abwechselnd gegeneinander antreten. Jeder Agent aktualisiert seine Gewichte, während der andere als Gegner fungiert. Starten lässt sich das Training mit:
+
+```bash
+python -m agent.multiagent_selfplay
+```
+
+## Vier-Agenten-Selbstspiel (RLlib)
+
+Mit `agent/train_rllib_selfplay.py` können vier Agenten parallel mittels RLlib trainiert werden. Das Skript speichert die erlernten Politiken nach dem Training im Ordner `rllib_blokus_agents`.
+
+```bash
+python -m agent.train_rllib_selfplay
+```
+
+## Tests und Beispielumgebung
+
+Zum schnellen Testen der Umgebung steht `agent/test.py` zur Verfügung. Darin wird ein zufälliger Agent über 100 Schritte ausgeführt und das Spielfeld nach jedem Zug ausgegeben:
+
+```bash
+python -m agent.test
+```
+
+Für zusätzliche Sicherungen der Umgebung existieren weitere PyTest-Tests im Verzeichnis `agent/`.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,34 @@
 # Blokus Reinforcement Learning
 
-This repository implements a small experiment using reinforcement learning for the board game Blokus. The environment is based on `gymnasium` and supports masked actions.
+Dieses Projekt untersucht Reinforcement-Learning-Ansätze für das Brettspiel **Blokus**. Die Umgebung ist in `gymnasium` implementiert und ermöglicht maskierte Aktionen.
 
-## Multi-agent training
+## Installation
 
-The new script `agent/multiagent_selfplay.py` demonstrates how two independent PPO agents can be trained against each other using self-play. Each agent alternates as the opponent for the other and the weights are updated in turns.
+Das Projekt benötigt Python 3.11 oder neuer. Die Abhängigkeiten befinden sich in `requirements.txt` und lassen sich beispielsweise mit `pip` installieren:
 
-Run the script as a normal Python module once the dependencies from `pyproject.toml` are installed.
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
 
-uv run python -m agent.test
+## Tests
 
-## 4-agent self-play
+Zur Verifikation der Umgebung und der Agenten stehen einige PyTest-Tests bereit. Sie können diese mit folgendem Befehl ausführen:
 
-`agent/train_rllib_selfplay.py` uses RLlib to train one PPO policy per player in a 4-agent self-play scenario. The algorithm periodically reports the mean episode reward and saves all policies once training finishes.
+```bash
+pytest
+```
 
-uv run python -m agent.train_rllib_selfplay
+## Beispielskripte
+
+- `agent/multiagent_selfplay.py` trainiert zwei PPO-Agenten im Selbstspiel gegeneinander.
+- `agent/train_rllib_selfplay.py` verwendet RLlib, um vier Agenten parallel im Selbstspiel zu trainieren.
+
+Die Skripte lassen sich direkt als Python-Module ausführen, sobald alle Abhängigkeiten installiert sind, z.B.:
+
+```bash
+python -m agent.multiagent_selfplay
+```
+
+Weitere Details zur Verwendung der Agenten finden sich in [Agent.md](Agent.md).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+colorama>=0.4.6
+dm-tree>=0.1.9
+lz4>=4.4.4
+ray[tune]>=2.46.0
+sb3-contrib>=2.6.0
+scipy>=1.15.3
+stable-baselines3>=2.6.0
+tensorboard>=2.19.0
+tensorflow>=2.19.0


### PR DESCRIPTION
## Summary
- add German README
- add Agent documentation for training scripts
- create requirements.txt with dependencies from `pyproject.toml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_68485fcbc8fc8331b9d6faef092e5415