### PR TITLE
Add dependency checker and simple PPO training script

### DIFF
--- a/test_requirements.py
+++ b/test_requirements.py
@@ -1,0 +1,43 @@
+import importlib
+import sys
+
+
+def read_requirements(path="requirements.txt"):
+    packages = []
+    try:
+        with open(path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    continue
+                # remove version specifiers and extras
+                pkg = line.split('==')[0].split('>=')[0].split('<=')[0]
+                pkg = pkg.split('[')[0]
+                if pkg:
+                    packages.append(pkg)
+    except FileNotFoundError:
+        pass
+    return packages
+
+
+def main():
+    pkgs = set(read_requirements())
+    # Explicitly check important packages
+    pkgs.update([
+        "gymnasium",
+        "ray.rllib",
+        "env.blokus_env_multi_agent_ray_rllib",
+    ])
+
+    for pkg in pkgs:
+        try:
+            importlib.import_module(pkg)
+        except Exception as e:
+            print(f"Fehler beim Import von {pkg}: {e}")
+            sys.exit(1)
+    print("\u2713 Dependencies OK")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/train_blokus.py
+++ b/train_blokus.py
@@ -1,0 +1,69 @@
+import subprocess
+import sys
+
+
+def check_dependencies():
+    result = subprocess.run([sys.executable, "test_requirements.py"])
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
+def main():
+    check_dependencies()
+
+    from ray.rllib.algorithms.ppo import PPOConfig
+    from ray.rllib.policy.policy import PolicySpec
+    from ray.tune.registry import register_env
+    from env.blokus_env_multi_agent_ray_rllib import BlokusMultiAgentEnv
+
+    def env_creator(config=None):
+        env = BlokusMultiAgentEnv(config)
+        if not hasattr(env, "observation_space"):
+            env.observation_space = env.observation_spaces[env.possible_agents[0]]
+        if not hasattr(env, "action_space"):
+            env.action_space = env.action_spaces[env.possible_agents[0]]
+        return env
+
+    register_env("blokus_multi_agent", env_creator)
+
+    dummy = env_creator()
+    obs_space = dummy.observation_spaces[dummy.possible_agents[0]]
+    act_space = dummy.action_spaces[dummy.possible_agents[0]]
+
+    config = (
+        PPOConfig()
+        .environment("blokus_multi_agent")
+        .framework("tf2")
+        .api_stack(enable_rl_module_and_learner=False,
+                   enable_env_runner_and_connector_v2=False)
+        .env_runners(num_env_runners=0)
+        .multi_agent(
+            policies={
+                "shared": PolicySpec(
+                    observation_space=obs_space,
+                    action_space=act_space,
+                    config={},
+                )
+            },
+            policy_mapping_fn=lambda agent_id, *args, **kwargs: "shared",
+        )
+        .rl_module(
+            model_config={
+                "use_action_masking": True,
+                "fcnet_hiddens": [256, 256],
+            }
+        )
+        .training(train_batch_size=200)
+    )
+
+    algo = config.build()
+
+    dummy.reset()
+    for _ in range(2):
+        algo.train()
+
+    print("Sanity check passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `test_requirements.py` for verifying imports of important packages
- add `train_blokus.py` that runs the dependency check and performs a short PPO sanity run using RLlib

## Testing
- `pytest -q`
- `python train_blokus.py`

------
https://chatgpt.com/codex/tasks/task_e_6862b279d5648331b1bdc6639499e876